### PR TITLE
Fix flipdot logo partially hidden

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -65,10 +65,6 @@ header.d-header {
     margin: 5px 0;
 }
 
-.d-header .title {
-    margin-top: -5px;
-}
-
 .d-header .panel {
     margin-top: -2px;
     margin-bottom: 2px;


### PR DESCRIPTION
Vorher
<img width="530" alt="image" src="https://github.com/user-attachments/assets/194f9de7-e6eb-4455-a5e9-5c25e08e2027">

Nachher
<img width="608" alt="image" src="https://github.com/user-attachments/assets/4161790a-847e-4fe6-88a8-249e72901380">
